### PR TITLE
expose ImagePreprocessorOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
-import imagePreprocessor from './preprocessor/image-preprocessor';
-export { imagePreprocessor };
+export {
+  default as imagePreprocessor,
+  type ImagePreprocessorOptions,
+} from './preprocessor/image-preprocessor';
 
 import Image from './Image';
 export default Image;


### PR DESCRIPTION
I'm working on writing a package that uses your fantastic imagePreprocessor and would like to be able to reference the options type directly