### PR TITLE
Update README.md to use vitePreprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install -D svimg
 
 In `svelte.config.js`, add `imagePreprocessor` as a preprocessor:
 ```js
-import preprocess from 'svelte-preprocess';
+import { vitePreprocess } from '@sveltejs/kit/vite';
 import { imagePreprocessor } from 'svimg';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -31,7 +31,7 @@ const config = {
             webp: true,
             avif: true
         }), 
-        preprocess()
+        vitePreprocess()
     ]
 };
 


### PR DESCRIPTION
Given vitePreprocess is [now the default for new SvelteKit projects](https://kit.svelte.dev/docs/integrations#preprocessors-vitepreprocess), it'd be useful to include this as an example in svgimg's Readme.

Closes https://github.com/xiphux/svimg/issues/38